### PR TITLE
ci: harden secure note validation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,5 +19,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
       - name: Validate project and note baseline
         run: make check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+## Repository purpose
+
+`garethpaul/ios-note-taker` is an Apple platform application or Swift sample. A simple note taker for ios
+
+## Project structure
+
+- `Makefile` - repository verification targets
+- `scripts` - baseline checks and helper scripts
+- `docs` - plans, notes, and generated README assets
+- `NoteTaker.xcodeproj` - Xcode project
+- `img` - repository source or sample assets
+- `NoteTaker` - repository source or sample assets
+- `NoteTakerTests` - repository source or sample assets
+- `NoteTakerUITests` - repository source or sample assets
+
+## Development commands
+
+- Install dependencies: no repository-specific install command is documented.
+- Full baseline: `make check`
+- Local Apple development: `open NoteTaker.xcodeproj`
+- If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
+
+## Coding conventions
+
+- Language mix noted in the README: Swift (10), shell (1).
+- Preserve legacy Xcode project settings and signing assumptions unless the change is explicitly about modernization.
+
+## Testing guidance
+
+- Test-related files detected: `NoteTaker.xcodeproj/xcshareddata/xcschemes/NoteTakerTests.xcscheme`, `NoteTaker/NoteStore.swift`, `NoteTakerTests/NoteTakerTests.swift`, `NoteTakerUITests/NoteTakerUITests.swift`
+- Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
+- Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
+
+## PR / change guidance
+
+- Keep diffs focused on the requested repository and avoid unrelated modernization or formatting churn.
+- Preserve public APIs, sample behavior, file formats, and documented environment variables unless the task explicitly changes them.
+- Update tests, README notes, or docs/plans when behavior, security posture, or validation commands change.
+- Call out skipped platform validation, legacy toolchain assumptions, and any risky files touched in the final summary.
+
+## Safety and gotchas
+
+- No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
+- Keep signing files, local xcconfig files, and environment files out of git.
+- Notes can contain sensitive personal information. Keep note content local by default, avoid logging note content, and require explicit design before adding sync, upload, analytics, or export behavior.
+- `scripts/check-baseline.py` verifies local persistence saves, archive file protection, archive fallback behavior, storyboard cast guards, invalid hex fallback, and static privacy guardrails.
+- This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
+- See `SECURITY.md` for vulnerability reporting and safe research guidance.
+
+## Agent workflow
+
+1. Inspect the README, Makefile, manifests, and the files directly related to the request.
+2. Make the smallest source or docs change that satisfies the task; avoid generated, vendored, or local-environment files unless required.
+3. Run the narrowest useful validation first, then `make check` or the documented package/platform gate when available.
+4. If a required SDK, service credential, or external runtime is unavailable, record the skipped command and why.
+5. Summarize changed files, commands run, and remaining risks or follow-up validation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@
   builds of the app and unit-test targets.
 - Added reference delete result handling so object-based note deletes report
   whether they actually removed and saved a note.
-- Added pinned, read-only macOS CI for the canonical `make check` baseline.
+- Added pinned, read-only macOS CI with Python 3.12 and no persisted checkout
+  credentials for the canonical `make check` baseline.
 - Made Xcode-enabled checks parse `NoteTaker.xcodeproj` and its shared schemes
   without opening note archives or accessing local note content.
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ stay available while preserving the single source of truth.
 
 The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/scheme XML, checks Swift 5 project metadata, verifies secure-coding round trips, title normalization tests, decoded title fallback behavior, guarded note lookup, delete result handling, reference delete result handling, navigation logo title view ownership, atomic local note persistence, archive documents path guards, archive file protection, source inventory, no note-content logging, and no network/sync/upload/analytics behavior.
 
-The pinned GitHub Actions check runs `make check` on `macos-15`. When Xcode is
-available, the baseline also compiles the unsigned Swift 5 app and unit-test
-bundle for the iOS Simulator. It does not launch the app, open user note
-archives, read note content, or use signing material.
+The pinned, credential-free GitHub Actions check sets up Python 3.12 and runs
+`make check` on `macos-15`. The baseline compiles the unsigned Swift 5 app and
+unit-test bundle for the iOS Simulator. It does not launch the app, open user
+note archives, read note content, or use signing material.
 
 For runtime verification on macOS, use the shared Xcode schemes to run the unit
 tests and exercise create, edit, delete, and relaunch persistence flows.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,9 +28,10 @@ Helpful reports include:
 - Note content is sensitive local app data. The current app stores notes locally through `NoteStore.plist`, applies platform file protection after successful saves, and should not log, sync, upload, analyze, or transmit note content.
 - Persistence, archive decoding, export, sharing, sync, analytics, or network changes should receive security-focused review before merge.
 - Run `make check` before merging changes; it verifies plist/storyboard/scheme metadata, secure coding, atomic archive writes, title normalization, decoded title fallback behavior, guarded note lookup, delete result handling, reference delete result handling, navigation logo title view ownership, file protection, archive fallback behavior, source inventory, and note-content privacy guardrails.
-- The pinned macOS workflow uses read-only repository permissions and compiles
-  the unsigned app and unit-test bundle without opening user archives, reading
-  note content, or using signing material.
+- The pinned macOS workflow uses Python 3.12, read-only repository permissions,
+  and disabled checkout credential persistence. It compiles the unsigned app
+  and unit-test bundle without opening user archives, reading note content, or
+  using signing material.
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
 
 ## Mobile Privacy Notes

--- a/VISION.md
+++ b/VISION.md
@@ -32,8 +32,8 @@ Priority:
 - Keep `make lint`, `make test`, `make build`, and `make check` available as
   local verification gates
 - Keep app, unit-test, and UI-test targets on Swift 5 with iOS 12 deployment
-- Keep pinned macOS CI compiling the unsigned app and unit-test bundle through
-  the canonical `make check` gate
+- Keep pinned, credential-free macOS CI on Python 3.12, compiling the unsigned
+  app and unit-test bundle through the canonical `make check` gate
 
 Next priorities:
 

--- a/docs/plans/2026-06-10-hosted-project-validation.md
+++ b/docs/plans/2026-06-10-hosted-project-validation.md
@@ -11,12 +11,16 @@ project-file check.
 
 ## Completed Scope
 
-- Added a pinned GitHub Actions workflow with read-only repository permissions.
+- Added a pinned GitHub Actions workflow with read-only repository permissions
+  and disabled checkout credential persistence.
+- Pinned Python 3.12 setup for the canonical checker.
 - Runs the canonical `make check` gate on a bounded `macos-15` job.
 - Parses `NoteTaker.xcodeproj` and its shared schemes whenever Xcode is
   available.
-- Kept note archives, local note content, simulator builds, and signing outside
-  hosted CI.
+- Compiles the unsigned app and unit-test bundle for the iOS Simulator without
+  launching either target.
+- Kept note archives, local note content, simulator execution, and signing
+  outside hosted CI.
 - Extended the checker and documentation to preserve the CI contract.
 
 ## Verification

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import ast
 from pathlib import Path
 import plistlib
 import re
@@ -60,6 +61,38 @@ def parse_plist(relative_path, failures):
     except Exception as error:
         failures.append(f"{relative_path} is not a readable plist: {error}")
         return {}
+
+
+def has_unsigned_simulator_build(checker):
+    required_arguments = {
+        "xcodebuild",
+        "-project",
+        "NoteTaker.xcodeproj",
+        "-target",
+        "NoteTakerTests",
+        "-configuration",
+        "Debug",
+        "-sdk",
+        "iphonesimulator",
+        "CODE_SIGNING_ALLOWED=NO",
+        "build",
+    }
+    try:
+        tree = ast.parse(checker)
+    except SyntaxError:
+        return False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.List):
+            continue
+        arguments = {
+            element.value
+            for element in node.elts
+            if isinstance(element, ast.Constant) and isinstance(element.value, str)
+        }
+        if required_arguments.issubset(arguments):
+            return True
+    return False
 
 
 def main():
@@ -139,6 +172,7 @@ def main():
     vision = read("VISION.md")
     security = read("SECURITY.md")
     changes = read("CHANGES.md")
+    checker = read("scripts/check-baseline.py")
     gitignore = read(".gitignore")
     makefile = read("Makefile")
     baseline_plan = BASELINE_PLAN.read_text(encoding="utf-8") if BASELINE_PLAN.exists() else ""
@@ -181,8 +215,9 @@ def main():
 
     require("class Note: NSObject, NSSecureCoding" in note and
             "static var supportsSecureCoding: Bool { true }" in note and
-            "decodeObject(of: NSString.self" in note and
-            "decodeObject(of: NSDate.self" in note,
+            'decodeObject(of: NSString.self, forKey: "title") as? String' in note and
+            'decodeObject(of: NSString.self, forKey: "text") as? String ?? ""' in note and
+            'decodeObject(of: NSDate.self, forKey: "date") as? Date ?? Date()' in note,
             "Note decoding must tolerate missing or incompatible archived fields",
             failures)
     require("[UIApplication.LaunchOptionsKey: Any]?" in app_sources,
@@ -253,7 +288,7 @@ def main():
             "getNote(index:) must reject invalid note indexes instead of indexing directly",
             failures)
     require("NSKeyedUnarchiver.unarchivedObject(ofClasses: allowedClasses, from: data) as? [Note] ?? []" in store and
-            "notes = []" in store and
+            "} catch {\n            notes = []\n        }" in store and
             "let allowedClasses: [AnyClass] = [NSArray.self, Note.self, NSString.self, NSDate.self]" in store,
             "load must fall back to an empty note list for invalid archives",
             failures)
@@ -382,22 +417,31 @@ def main():
     require("status: completed" in reference_delete_plan,
             "note reference delete result plan must be marked completed",
             failures)
-    require("status: completed" in hosted_validation_plan and "make check" in hosted_validation_plan,
-            "hosted project validation plan must be completed and document make check",
+    require("status: completed" in hosted_validation_plan and "make check" in hosted_validation_plan and
+            "Python 3.12" in hosted_validation_plan and "credential persistence" in hosted_validation_plan,
+            "hosted project validation plan must document completion, Python 3.12, and credential handling",
             failures)
     require("status: completed" in secure_swift_5_plan and "NSSecureCoding" in secure_swift_5_plan,
             "secure Swift 5 persistence plan must be completed and document NSSecureCoding",
             failures)
-    require("permissions:\n  contents: read" in workflow,
-            "Check workflow must use read-only repository permissions",
+    require(workflow.count("permissions:\n  contents: read") == 1 and
+            not re.search(r"(?m)^\s{2,}permissions:\s*$", workflow) and
+            not re.search(r"(?m)^\s+[A-Za-z0-9_-]+:\s*write\s*$", workflow),
+            "Check workflow must use one top-level read-only permissions block",
             failures)
     require("cancel-in-progress: true" in workflow and "runs-on: macos-15" in workflow and
             "timeout-minutes: 10" in workflow,
             "Check workflow must bound duplicate and long-running macOS jobs",
             failures)
-    require("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" in workflow and
+    require(workflow.count("uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10") == 1 and
+            "persist-credentials: false" in workflow and
+            workflow.count("uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065") == 1 and
+            'python-version: "3.12"' in workflow and
             "run: make check" in workflow,
-            "Check workflow must pin checkout and run the canonical baseline",
+            "Check workflow must pin credential-free checkout and Python 3.12 before running the canonical baseline",
+            failures)
+    require(has_unsigned_simulator_build(checker),
+            "Checker must preserve the unsigned NoteTakerTests simulator build command",
             failures)
 
     if shutil.which("xcodebuild"):


### PR DESCRIPTION
## Summary

Hosted note validation now uses immutable, credential-free tooling while preserving the secure local persistence boundary. The macOS job sets up Python 3.12, runs the canonical baseline, and compiles the unsigned Swift 5 app and unit-test bundle without launching the app, opening archives, or reading note content.

The checker now distinguishes every class-restricted decoded field, requires the corrupt-archive catch path to clear the store, and structurally verifies the actual unsigned `xcodebuild` command even on hosts without Xcode. Contributor and hosted-validation guidance now accurately describe which compilation occurs in CI and which execution, signing, and note-data operations remain excluded.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- Python checker compilation
- Workflow, plist, project, scheme, storyboard, XIB, and SVG metadata parsing
- POSIX shell syntax check for `build.sh`
- Twenty-three hostile mutations rejected; one harmless workflow extension accepted
- Conflict-marker, secret, and `git diff --check` scans

Local validation ran on Linux without Xcode. Hosted macOS validation is authoritative for compiling the unsigned app and unit-test bundle.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
