### PR TITLE
security: protect note archives during atomic writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@
 - No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
 - Keep signing files, local xcconfig files, and environment files out of git.
 - Notes can contain sensitive personal information. Keep note content local by default, avoid logging note content, and require explicit design before adding sync, upload, analytics, or export behavior.
-- `scripts/check-baseline.py` verifies local persistence saves, archive file protection, archive fallback behavior, storyboard cast guards, invalid hex fallback, and static privacy guardrails.
+- `scripts/check-baseline.py` verifies protected atomic local persistence saves, explicit archive file-protection repair, archive fallback behavior, storyboard cast guards, invalid hex fallback, and static privacy guardrails.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-12
+
+- Requested complete file protection as part of each atomic secure note archive
+  write, while retaining explicit attribute repair.
+
 ## 2026-06-10
 
 - Migrated app, unit-test, and UI-test targets from Swift 2-era syntax to Swift 5

--- a/NoteTaker/NoteStore.swift
+++ b/NoteTaker/NoteStore.swift
@@ -87,7 +87,7 @@ class NoteStore {
         }
         do {
             let data = try NSKeyedArchiver.archivedData(withRootObject: notes, requiringSecureCoding: true)
-            try data.write(to: url, options: .atomic)
+            try data.write(to: url, options: [.atomic, .completeFileProtection])
             applyFileProtection(url.path)
         } catch {
             // Keep the in-memory notes available when local persistence fails.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The checked-in project has no external dependency manifest. Use Xcode for full b
 - Reference delete results report whether the requested note object was removed.
 - The mini logo is scoped to each navigation item title view instead of being
   added as a navigation-controller overlay.
-- Notes are local app data stored through `NoteStore.plist` in the app documents area with platform file protection applied after successful saves. If the documents path is unavailable, the store keeps an empty in-memory list instead of writing to a fallback path. The app does not sync, upload, or analyze note content.
+- Notes are local app data stored through `NoteStore.plist` in the app documents area. Saves request complete file protection as part of the atomic replacement and then repair the resulting file attributes explicitly. If the documents path is unavailable, the store keeps an empty in-memory list instead of writing to a fallback path. The app does not sync, upload, or analyze note content.
 
 ## Testing and Verification
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,9 +25,9 @@ Helpful reports include:
 ## Project Security Posture
 
 - This repository appears to be an Apple platform application or Swift sample. The active security scope is the code and documentation on the default branch.
-- Note content is sensitive local app data. The current app stores notes locally through `NoteStore.plist`, applies platform file protection after successful saves, and should not log, sync, upload, analyze, or transmit note content.
+- Note content is sensitive local app data. The current app stores notes locally through `NoteStore.plist`, requests complete file protection during each atomic replacement, repairs the resulting file attributes explicitly, and should not log, sync, upload, analyze, or transmit note content.
 - Persistence, archive decoding, export, sharing, sync, analytics, or network changes should receive security-focused review before merge.
-- Run `make check` before merging changes; it verifies plist/storyboard/scheme metadata, secure coding, atomic archive writes, title normalization, decoded title fallback behavior, guarded note lookup, delete result handling, reference delete result handling, navigation logo title view ownership, file protection, archive fallback behavior, source inventory, and note-content privacy guardrails.
+- Run `make check` before merging changes; it verifies plist/storyboard/scheme metadata, secure coding, protected atomic archive writes, title normalization, decoded title fallback behavior, guarded note lookup, delete result handling, reference delete result handling, navigation logo title view ownership, file-protection repair, archive fallback behavior, source inventory, and note-content privacy guardrails.
 - The pinned macOS workflow uses Python 3.12, read-only repository permissions,
   and disabled checkout credential persistence. It compiles the unsigned app
   and unit-test bundle without opening user archives, reading note content, or

--- a/VISION.md
+++ b/VISION.md
@@ -24,7 +24,7 @@ Priority:
 - Keep note delete result handling aligned between the store and table view
 - Keep reference delete result handling explicit for object-based deletes
 - Keep the mini logo scoped to each navigation item title view
-- Keep the local note archive protected after successful saves
+- Request complete file protection during atomic note archive replacement and retain explicit attribute repair
 - Avoid fallback archive writes when the documents path is unavailable
 - Maintain build script and README context
 - Keep `scripts/check-baseline.py` passing for local-first persistence,
@@ -60,10 +60,10 @@ explicit.
 
 Current baseline: `make lint`, `make test`, `make build`, and `make check` run
 `scripts/check-baseline.py` without Xcode. It verifies plist/storyboard/scheme
-metadata, secure and atomic local `NoteStore.plist` persistence, title normalization, decoded title
+metadata, secure and protected atomic local `NoteStore.plist` persistence, title normalization, decoded title
 fallback behavior, guarded note lookup, delete result handling, reference delete
 result handling, navigation logo title view ownership, documents path guards,
-archive file protection, archive fallback behavior, and no logging, sync,
+archive file-protection repair, archive fallback behavior, and no logging, sync,
 analytics, upload, or network behavior in app sources.
 On macOS, the baseline should compile the unsigned app and unit-test bundle
 without launching the app, opening user archives, or accessing note content.

--- a/docs/plans/2026-06-12-protected-atomic-note-write.md
+++ b/docs/plans/2026-06-12-protected-atomic-note-write.md
@@ -1,0 +1,27 @@
+# Protected Atomic Note Write
+
+status: planned
+
+## Context
+
+`NoteStore.save()` writes the secure archive atomically and applies complete file
+protection afterward. The replacement archive therefore depends on a second
+filesystem operation before it has the intended protection class, and a failed
+attribute update can leave newly written note content less protected than
+expected.
+
+## Scope
+
+- Request complete file protection as part of the atomic data write.
+- Retain the explicit attribute update to repair existing or platform-specific
+  archive metadata.
+- Extend the static persistence contract with write-option ordering checks.
+- Preserve secure coding, the Documents archive location, and local-only data
+  behavior.
+
+## Verification
+
+- `make check`
+- `git diff --check`
+- Mutations removing complete protection from the write must fail the baseline.
+- Hosted macOS validation must compile the Swift 5 note target.

--- a/docs/plans/2026-06-12-protected-atomic-note-write.md
+++ b/docs/plans/2026-06-12-protected-atomic-note-write.md
@@ -1,6 +1,6 @@
 # Protected Atomic Note Write
 
-status: planned
+status: completed
 
 ## Context
 
@@ -10,7 +10,7 @@ filesystem operation before it has the intended protection class, and a failed
 attribute update can leave newly written note content less protected than
 expected.
 
-## Scope
+## Completed Scope
 
 - Request complete file protection as part of the atomic data write.
 - Retain the explicit attribute update to repair existing or platform-specific

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -22,6 +22,7 @@ NAV_LOGO_PLAN = ROOT / "docs/plans/2026-06-09-navigation-logo-title-view.md"
 REFERENCE_DELETE_PLAN = ROOT / "docs/plans/2026-06-10-note-reference-delete-result.md"
 HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
 SECURE_SWIFT_5_PLAN = ROOT / "docs/plans/2026-06-10-secure-swift-5-persistence.md"
+PROTECTED_WRITE_PLAN = ROOT / "docs/plans/2026-06-12-protected-atomic-note-write.md"
 
 
 def require(condition, message, failures):
@@ -139,6 +140,7 @@ def main():
         "docs/plans/2026-06-10-note-reference-delete-result.md",
         "docs/plans/2026-06-10-hosted-project-validation.md",
         "docs/plans/2026-06-10-secure-swift-5-persistence.md",
+        "docs/plans/2026-06-12-protected-atomic-note-write.md",
         "img/app.gif",
     ]
 
@@ -187,6 +189,7 @@ def main():
     reference_delete_plan = REFERENCE_DELETE_PLAN.read_text(encoding="utf-8") if REFERENCE_DELETE_PLAN.exists() else ""
     hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
     secure_swift_5_plan = SECURE_SWIFT_5_PLAN.read_text(encoding="utf-8") if SECURE_SWIFT_5_PLAN.exists() else ""
+    protected_write_plan = PROTECTED_WRITE_PLAN.read_text(encoding="utf-8") if PROTECTED_WRITE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(app_plist.get("CFBundlePackageType") == "APPL",
@@ -269,10 +272,10 @@ def main():
             "guard let url = archiveFileURL() else",
             "return",
             "NSKeyedArchiver.archivedData(withRootObject: notes, requiringSecureCoding: true)",
-            "data.write(to: url, options: .atomic)",
+            "data.write(to: url, options: [.atomic, .completeFileProtection])",
             "applyFileProtection(url.path)",
         ],
-        "save must securely archive, atomically write, and then protect note data",
+        "save must securely archive, atomically write protected note data, and repair attributes",
         failures,
     )
     require("func applyFileProtection(_ path: String)" in store and
@@ -423,6 +426,9 @@ def main():
             failures)
     require("status: completed" in secure_swift_5_plan and "NSSecureCoding" in secure_swift_5_plan,
             "secure Swift 5 persistence plan must be completed and document NSSecureCoding",
+            failures)
+    require("status: completed" in protected_write_plan and "mutation" in protected_write_plan.lower(),
+            "protected atomic note write plan must record completed mutation verification",
             failures)
     require(workflow.count("permissions:\n  contents: read") == 1 and
             not re.search(r"(?m)^\s{2,}permissions:\s*$", workflow) and


### PR DESCRIPTION
## Summary

- request complete file protection as part of the atomic `NoteStore.plist` replacement
- retain explicit file-attribute repair after a successful write
- extend the static baseline and documentation to enforce the protected-write invariant

## Verification

- `make lint`
- `make test`
- `make build`
- `make check`
- `python3 -m py_compile scripts/check-baseline.py`
- `git diff --check`
- mutation proof: replacing `[.atomic, .completeFileProtection]` with `.atomic` is rejected by the baseline

## Runtime note

This Linux checkout cannot run Xcode or exercise iOS file-protection semantics. The hosted macOS workflow compiles the unsigned app and unit-test bundle without accessing note content or signing material.
