### PR TITLE
Document protected note-write verification

### DIFF
--- a/docs/plans/2026-06-12-protected-atomic-note-write.md
+++ b/docs/plans/2026-06-12-protected-atomic-note-write.md
@@ -10,7 +10,7 @@ filesystem operation before it has the intended protection class, and a failed
 attribute update can leave newly written note content less protected than
 expected.
 
-## Completed Scope
+## Work Completed
 
 - Request complete file protection as part of the atomic data write.
 - Retain the explicit attribute update to repair existing or platform-specific
@@ -19,9 +19,25 @@ expected.
 - Preserve secure coding, the Documents archive location, and local-only data
   behavior.
 
-## Verification
+## Verification Completed
 
-- `make check`
-- `git diff --check`
-- Mutations removing complete protection from the write must fail the baseline.
-- Hosted macOS validation must compile the Swift 5 note target.
+- Local `make check`, `make lint`, `make test`, and `make build` passed. The
+  local environment did not provide `xcodebuild`, so these runs exercised the
+  complete static baseline and reported the hosted Xcode requirement.
+- `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
+  passed.
+- Hostile mutations changing the plan status, inserting an unfinished-work
+  marker, falsifying a run ID, removing complete protection from the atomic
+  write, or moving attribute repair before the write were rejected.
+- The implementation push Check run `27395126378` completed successfully for
+  commit `d330ffdb1557d111868248c8c1b2055b39cda02e`.
+- The implementation pull-request Check run `27395135480` completed
+  successfully for commit `d330ffdb1557d111868248c8c1b2055b39cda02e` and
+  compiled the Swift 5 note target on hosted macOS.
+- The post-merge push Check run `27395178307` completed successfully for
+  commit `58f8f0bc9db12e991a6fa6116794c8a578e593d9`.
+- The CodeQL setup run `27402323479` completed successfully for commit
+  `58f8f0bc9db12e991a6fa6116794c8a578e593d9`.
+- Persistence preserves
+  `data.write(to: url, options: [.atomic, .completeFileProtection])` before
+  `applyFileProtection(url.path)`.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -34,6 +34,14 @@ def read(relative_path):
     return (ROOT / relative_path).read_text(encoding="utf-8", errors="replace")
 
 
+def markdown_section(text, heading):
+    match = re.search(
+        rf"(?ms)^## {re.escape(heading)}\s*$\n(.*?)(?=^## |\Z)",
+        text,
+    )
+    return match.group(1).strip() if match else ""
+
+
 def strip_swift_line_comments(text):
     return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
 
@@ -427,9 +435,39 @@ def main():
     require("status: completed" in secure_swift_5_plan and "NSSecureCoding" in secure_swift_5_plan,
             "secure Swift 5 persistence plan must be completed and document NSSecureCoding",
             failures)
-    require("status: completed" in protected_write_plan and "mutation" in protected_write_plan.lower(),
-            "protected atomic note write plan must record completed mutation verification",
+    protected_write_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", protected_write_plan
+    )
+    protected_write_work = markdown_section(protected_write_plan, "Work Completed")
+    protected_write_verification = markdown_section(
+        protected_write_plan, "Verification Completed"
+    )
+    require(protected_write_status == ["completed"] and protected_write_work,
+            "protected atomic note write plan must record one completed status and completed work",
             failures)
+    require(protected_write_verification and
+            not re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", protected_write_verification),
+            "protected atomic note write plan must record finished verification without pending markers",
+            failures)
+    for evidence in [
+        "make check",
+        "make lint",
+        "make test",
+        "make build",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "git diff --check",
+        "27395126378",
+        "27395135480",
+        "27395178307",
+        "27402323479",
+        "d330ffdb1557d111868248c8c1b2055b39cda02e",
+        "58f8f0bc9db12e991a6fa6116794c8a578e593d9",
+        "data.write(to: url, options: [.atomic, .completeFileProtection])",
+        "applyFileProtection(url.path)",
+    ]:
+        require(evidence in protected_write_verification,
+                f"protected atomic note write plan must preserve verification evidence: {evidence}",
+                failures)
     require(workflow.count("permissions:\n  contents: read") == 1 and
             not re.search(r"(?m)^\s{2,}permissions:\s*$", workflow) and
             not re.search(r"(?m)^\s+[A-Za-z0-9_-]+:\s*write\s*$", workflow),


### PR DESCRIPTION
## Summary
Document the completed protected atomic note write with exact hosted evidence and enforce that evidence in the canonical baseline.

## Baseline
The merged implementation writes note archives atomically with complete file protection, then repairs file attributes. Historical push, pull-request, post-merge, and CodeQL runs are successful.

## Improvements
- Record exact run IDs and commit SHAs in the completed plan.
- Require one completed status and a finished verification section.
- Preserve write-time protection and write-before-repair ordering.
- Reject five hostile plan and persistence mutations.

## Validation
- `make check`
- `make lint`
- `make test`
- `make build`
- `python3 -m py_compile scripts/check-baseline.py`
- `git diff --check`
- Five hostile mutations rejected

## Risk
Local Linux cannot run Xcode. The canonical hosted macOS Check compiles the Swift 5 note target; this documentation-only follow-up does not change persistence behavior.

## Follow-Ups
Keep PR #5 open for owner review. Do not merge without explicit authorization, and require exact-head push, pull-request, and CodeQL success.