### PR TITLE
Restore existing note edit routing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Restored selected-note identity by assigning `NoteDetailPush` to the
+  prototype-cell segue used to edit existing notes.
+
 ## 2026-06-12
 
 - Requested complete file protection as part of each atomic secure note archive

--- a/NoteTaker/Base.lproj/Main.storyboard
+++ b/NoteTaker/Base.lproj/Main.storyboard
@@ -84,7 +84,7 @@
                                     <outlet property="noteDateLabel" destination="1oX-lO-eap" id="hzu-JA-BmN"/>
                                     <outlet property="noteTextLabel" destination="Xso-4E-BW8" id="Df6-k4-T4S"/>
                                     <outlet property="noteTitleLabel" destination="2bI-PN-1ZI" id="I83-GX-4mN"/>
-                                    <segue destination="ZZg-jO-NX9" kind="show" id="HEE-Ta-4gH"/>
+                                    <segue destination="ZZg-jO-NX9" kind="show" identifier="NoteDetailPush" id="HEE-Ta-4gH"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The `lint`, `test`, and `build` targets intentionally alias the canonical baseli
 on hosts without Xcode, so the standard local gate commands
 stay available while preserving the single source of truth.
 
-The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/scheme XML, checks Swift 5 project metadata, verifies secure-coding round trips, title normalization tests, decoded title fallback behavior, guarded note lookup, delete result handling, reference delete result handling, navigation logo title view ownership, atomic local note persistence, archive documents path guards, archive file protection, source inventory, no note-content logging, and no network/sync/upload/analytics behavior.
+The baseline runs `scripts/check-baseline.py`, parses plist/storyboard/scheme XML, checks Swift 5 project metadata, verifies secure-coding round trips, title normalization tests, decoded title fallback behavior, guarded note lookup, delete result handling, reference delete result handling, selected-note identity during edit navigation, navigation logo title view ownership, atomic local note persistence, archive documents path guards, archive file protection, source inventory, no note-content logging, and no network/sync/upload/analytics behavior.
 
 The pinned, credential-free GitHub Actions check sets up Python 3.12 and runs
 `make check` on `macos-15`. The baseline compiles the unsigned Swift 5 app and
@@ -100,6 +100,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 - Notes can contain sensitive personal information. Keep note content local by default, avoid logging note content, and require explicit design before adding sync, upload, analytics, or export behavior.
 - `scripts/check-baseline.py` verifies local persistence saves, archive file protection, archive fallback behavior, storyboard cast guards, invalid hex fallback, and static privacy guardrails.
+- Existing-note navigation keeps selected-note identity through the unique
+  `NoteDetailPush` cell segue; add-note routing remains separate.
 
 ## Maintenance Notes
 
@@ -111,6 +113,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-09-note-delete-result-guard.md` for the note delete result guardrail.
 - See `docs/plans/2026-06-10-note-reference-delete-result.md` for the reference delete result guardrail.
 - See `docs/plans/2026-06-09-navigation-logo-title-view.md` for the navigation logo title view guardrail.
+- See `docs/plans/2026-06-13-edit-note-segue-identifier.md` for the existing-note
+  edit routing guardrail.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Swift sources, plist/storyboard/scheme files, persistence behavior, build scripts, or privacy documentation.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ Helpful reports include:
 - This repository appears to be an Apple platform application or Swift sample. The active security scope is the code and documentation on the default branch.
 - Note content is sensitive local app data. The current app stores notes locally through `NoteStore.plist`, requests complete file protection during each atomic replacement, repairs the resulting file attributes explicitly, and should not log, sync, upload, analyze, or transmit note content.
 - Persistence, archive decoding, export, sharing, sync, analytics, or network changes should receive security-focused review before merge.
-- Run `make check` before merging changes; it verifies plist/storyboard/scheme metadata, secure coding, protected atomic archive writes, title normalization, decoded title fallback behavior, guarded note lookup, delete result handling, reference delete result handling, navigation logo title view ownership, file-protection repair, archive fallback behavior, source inventory, and note-content privacy guardrails.
+- Run `make check` before merging changes; it verifies plist/storyboard/scheme metadata, secure coding, protected atomic archive writes, title normalization, decoded title fallback behavior, guarded note lookup, delete result handling, reference delete result handling, selected-note identity during edit navigation, navigation logo title view ownership, file-protection repair, archive fallback behavior, source inventory, and note-content privacy guardrails.
 - The pinned macOS workflow uses Python 3.12, read-only repository permissions,
   and disabled checkout credential persistence. It compiles the unsigned app
   and unit-test bundle without opening user archives, reading note content, or

--- a/VISION.md
+++ b/VISION.md
@@ -23,6 +23,8 @@ Priority:
 - Keep note lookup guarded against stale or invalid table indexes
 - Keep note delete result handling aligned between the store and table view
 - Keep reference delete result handling explicit for object-based deletes
+- Keep selected-note identity aligned between cell-owned edit segues and the
+  detail controller
 - Keep the mini logo scoped to each navigation item title view
 - Request complete file protection during atomic note archive replacement and retain explicit attribute repair
 - Avoid fallback archive writes when the documents path is unavailable
@@ -62,8 +64,9 @@ Current baseline: `make lint`, `make test`, `make build`, and `make check` run
 `scripts/check-baseline.py` without Xcode. It verifies plist/storyboard/scheme
 metadata, secure and protected atomic local `NoteStore.plist` persistence, title normalization, decoded title
 fallback behavior, guarded note lookup, delete result handling, reference delete
-result handling, navigation logo title view ownership, documents path guards,
-archive file-protection repair, archive fallback behavior, and no logging, sync,
+result handling, selected-note identity during edit navigation, navigation logo
+title view ownership, documents path guards, archive file-protection repair,
+archive fallback behavior, and no logging, sync,
 analytics, upload, or network behavior in app sources.
 On macOS, the baseline should compile the unsigned app and unit-test bundle
 without launching the app, opening user archives, or accessing note content.

--- a/docs/plans/2026-06-13-edit-note-segue-identifier.md
+++ b/docs/plans/2026-06-13-edit-note-segue-identifier.md
@@ -1,6 +1,6 @@
 # Edit Note Segue Identifier
 
-status: planned
+status: completed
 
 ## Context
 
@@ -53,17 +53,25 @@ and preventing the intended reference-backed update path.
 - Do not add sync, networking, analytics, upload, logging, or telemetry.
 - Do not claim interactive simulator validation without Xcode.
 
-## Verification
+## Work Completed
 
-- `make lint`
-- `make test`
-- `make build`
-- `make check`
-- `python3 -m py_compile scripts/check-baseline.py`
-- Parse plist, storyboard, XIB, scheme, workspace, project, and workflow
-  metadata with available local parsers.
-- `sh -n build.sh`
-- `git diff --check`
-- Hostile mutations removing, renaming, relocating, or duplicating the edit
-  identifier, changing the add identifier, weakening controller guards, or
-  falsifying plan evidence must be rejected.
+- Assigned `NoteDetailPush` to the prototype-cell show segue that opens the
+  existing-note detail screen.
+- Added a parsed storyboard contract for unique cell-owned edit routing,
+  separate add routing, and the save unwind action.
+- Preserved guarded controller casts and selected-note assignment.
+- Documented the selected-note identity boundary across baseline guidance.
+
+## Verification Completed
+
+- All four Make gates, `make lint`, `make test`, `make build`, and `make check`,
+  passed against the complete static baseline.
+- `python3 -m py_compile scripts/check-baseline.py`, plist parsing, storyboard,
+  XIB, scheme, workspace, and SVG XML parsing, workflow YAML parsing,
+  `sh -n build.sh`, and `git diff --check` passed.
+- Eleven hostile mutations removing, renaming, duplicating, relocating, or
+  retargeting the edit segue, changing add or unwind routing, weakening the
+  destination cast, replacing selected-note assignment, or falsifying plan
+  status or verification evidence were rejected.
+- The local environment did not provide `xcodebuild`, so interactive edit
+  navigation and simulator execution were not claimed.

--- a/docs/plans/2026-06-13-edit-note-segue-identifier.md
+++ b/docs/plans/2026-06-13-edit-note-segue-identifier.md
@@ -1,0 +1,69 @@
+# Edit Note Segue Identifier
+
+status: planned
+
+## Context
+
+`TableViewController.prepare(for:sender:)` passes the selected note only for
+the `NoteDetailPush` segue. The prototype-cell show segue in `Main.storyboard`
+has no identifier, so tapping an existing row opens `DetailViewController` with
+its default blank note instead of the selected note.
+
+## Priority
+
+Editing an existing note is a primary workflow. The current storyboard and
+controller contract disagree silently, causing note content to appear missing
+and preventing the intended reference-backed update path.
+
+## Requirements
+
+- R1. Give the prototype-cell show segue the exact `NoteDetailPush` identifier.
+- R2. Preserve the add-button `NoteDetailAdd` segue and save unwind action.
+- R3. Preserve guarded destination and sender casts before assigning the
+  selected note to the detail controller.
+- R4. Parse the storyboard structurally and require the edit identifier on the
+  cell-owned show segue rather than accepting an unrelated matching string.
+- R5. Preserve secure local persistence, note identity, title normalization,
+  delete behavior, UI layout, and local-only privacy boundaries.
+- R6. Record completed local verification and hostile-mutation evidence.
+
+## Implementation Units
+
+### U1. Restore edit routing metadata
+
+- **File:** `NoteTaker/Base.lproj/Main.storyboard`
+- Add `identifier="NoteDetailPush"` to the existing prototype-cell show segue.
+
+### U2. Enforce storyboard-controller agreement
+
+- **File:** `scripts/check-baseline.py`
+- Locate the prototype table cell and require its show segue to target the
+  detail controller with the exact edit identifier.
+- Keep separate contracts for the add segue and save unwind action.
+
+### U3. Document the edit workflow guardrail
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Record that existing-note navigation must preserve selected-note identity.
+
+## Scope Boundaries
+
+- Do not change controller navigation logic, note model fields, archive format,
+  file protection, table layout, or save semantics.
+- Do not add sync, networking, analytics, upload, logging, or telemetry.
+- Do not claim interactive simulator validation without Xcode.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- Parse plist, storyboard, XIB, scheme, workspace, project, and workflow
+  metadata with available local parsers.
+- `sh -n build.sh`
+- `git diff --check`
+- Hostile mutations removing, renaming, relocating, or duplicating the edit
+  identifier, changing the add identifier, weakening controller guards, or
+  falsifying plan evidence must be rejected.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -23,6 +23,7 @@ REFERENCE_DELETE_PLAN = ROOT / "docs/plans/2026-06-10-note-reference-delete-resu
 HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
 SECURE_SWIFT_5_PLAN = ROOT / "docs/plans/2026-06-10-secure-swift-5-persistence.md"
 PROTECTED_WRITE_PLAN = ROOT / "docs/plans/2026-06-12-protected-atomic-note-write.md"
+EDIT_SEGUE_PLAN = ROOT / "docs/plans/2026-06-13-edit-note-segue-identifier.md"
 
 
 def require(condition, message, failures):
@@ -104,6 +105,43 @@ def has_unsigned_simulator_build(checker):
     return False
 
 
+def has_note_detail_storyboard_contract():
+    try:
+        root = ET.parse(ROOT / "NoteTaker/Base.lproj/Main.storyboard").getroot()
+    except (ET.ParseError, OSError):
+        return False
+
+    detail = root.find(".//viewController[@storyboardIdentifier='DetailViewController']")
+    cell = root.find(".//tableViewCell[@customClass='DetailTableViewCell']")
+    add_button = root.find(".//barButtonItem[@systemItem='add']")
+    save_button = root.find(".//barButtonItem[@systemItem='save']")
+    if detail is None or cell is None or add_button is None or save_button is None:
+        return False
+
+    detail_id = detail.get("id")
+    edit_segues = root.findall(".//segue[@identifier='NoteDetailPush']")
+    add_segues = root.findall(".//segue[@identifier='NoteDetailAdd']")
+    cell_segues = cell.findall("./connections/segue")
+    add_button_segues = add_button.findall("./connections/segue")
+    save_unwinds = save_button.findall("./connections/segue")
+
+    return (
+        len(edit_segues) == 1
+        and len(cell_segues) == 1
+        and edit_segues[0] is cell_segues[0]
+        and edit_segues[0].get("destination") == detail_id
+        and edit_segues[0].get("kind") == "show"
+        and len(add_segues) == 1
+        and len(add_button_segues) == 1
+        and add_segues[0] is add_button_segues[0]
+        and add_segues[0].get("destination") == detail_id
+        and add_segues[0].get("kind") == "show"
+        and len(save_unwinds) == 1
+        and save_unwinds[0].get("kind") == "unwind"
+        and save_unwinds[0].get("unwindAction") == "saveFromNoteDetail:"
+    )
+
+
 def main():
     failures = []
     required_files = [
@@ -149,6 +187,7 @@ def main():
         "docs/plans/2026-06-10-hosted-project-validation.md",
         "docs/plans/2026-06-10-secure-swift-5-persistence.md",
         "docs/plans/2026-06-12-protected-atomic-note-write.md",
+        "docs/plans/2026-06-13-edit-note-segue-identifier.md",
         "img/app.gif",
     ]
 
@@ -198,6 +237,7 @@ def main():
     hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
     secure_swift_5_plan = SECURE_SWIFT_5_PLAN.read_text(encoding="utf-8") if SECURE_SWIFT_5_PLAN.exists() else ""
     protected_write_plan = PROTECTED_WRITE_PLAN.read_text(encoding="utf-8") if PROTECTED_WRITE_PLAN.exists() else ""
+    edit_segue_plan = EDIT_SEGUE_PLAN.read_text(encoding="utf-8") if EDIT_SEGUE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(app_plist.get("CFBundlePackageType") == "APPL",
@@ -332,6 +372,11 @@ def main():
     require("as? DetailViewController" in table and "as? DetailTableViewCell" in table and "as? DetailTableViewCell" in table,
             "TableViewController must guard storyboard casts",
             failures)
+    require('segue.identifier == "NoteDetailPush"' in table and
+            "noteDetail.theNote = theNote" in table and
+            has_note_detail_storyboard_contract(),
+            "Storyboard edit routing must pass the selected note through the unique cell-owned NoteDetailPush segue",
+            failures)
     require("if NoteStore.sharedNoteStore.deleteNote(indexPath.row)" in table and
             "tableView.deleteRows(at: [indexPath], with: .fade)" in table,
             "TableViewController must delete visible rows only after store deletion succeeds",
@@ -380,24 +425,27 @@ def main():
             "file protection" in readme.lower() and "documents path" in readme.lower() and
             "title normalization" in readme.lower() and "decoded title" in readme.lower() and
             "note lookup" in readme.lower() and "delete result" in readme.lower() and
-            "reference delete" in readme.lower() and "title view" in readme.lower(),
+            "reference delete" in readme.lower() and "title view" in readme.lower() and
+            "selected-note identity" in readme.lower(),
             "README must document static verification, local note persistence, title normalization, path guards, and file protection",
             failures)
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "local-first" in vision.lower() and
             "documents path" in vision.lower() and "title normalization" in vision.lower() and "title view" in vision.lower() and
             "decoded title" in vision.lower() and "note lookup" in vision.lower() and "delete result" in vision.lower() and
-            "reference delete" in vision.lower(),
+            "reference delete" in vision.lower() and "selected-note identity" in vision.lower(),
             "VISION must describe the current static local-first baseline",
             failures)
     require("note content" in security.lower() and "make check" in security and
             "local" in security.lower() and "title normalization" in security.lower() and "title view" in security.lower() and
             "decoded title" in security.lower() and "note lookup" in security.lower() and "delete result" in security.lower() and
-            "reference delete" in security.lower(),
+            "reference delete" in security.lower() and "selected-note identity" in security.lower(),
             "SECURITY must document note-content privacy and static baseline guardrails",
             failures)
     require("persist" in changes.lower() and "archive" in changes.lower() and "file protection" in changes.lower() and
             "documents path" in changes.lower() and "title normalization" in changes.lower() and "decoded title" in changes.lower() and
-            "reference delete" in changes.lower() and "title view" in changes.lower() and "make check" in changes and "make lint" in changes and "make test" in changes and "make build" in changes,
+            "reference delete" in changes.lower() and "title view" in changes.lower() and
+            "selected-note identity" in changes.lower() and "make check" in changes and
+            "make lint" in changes and "make test" in changes and "make build" in changes,
             "CHANGES must record persistence hardening, title normalization, path guarding, file protection, and baseline",
             failures)
     require("note lookup" in changes.lower(),
@@ -434,6 +482,11 @@ def main():
             failures)
     require("status: completed" in secure_swift_5_plan and "NSSecureCoding" in secure_swift_5_plan,
             "secure Swift 5 persistence plan must be completed and document NSSecureCoding",
+            failures)
+    require("status: completed" in edit_segue_plan and
+            "All four Make gates" in edit_segue_plan and
+            "hostile mutations" in edit_segue_plan.lower(),
+            "edit note segue plan must record completed status and verification",
             failures)
     protected_write_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", protected_write_plan


### PR DESCRIPTION
## Summary

Restore the missing `NoteDetailPush` storyboard identifier so tapping an existing row passes that selected note into the detail controller instead of displaying the default blank note.

## Baseline

This PR is stacked on `lfg/ios-note-taker-evidence-20260612` / PR #5 and contains only the edit-routing repair and its verification evidence. The published branch name predates defect selection and is retained to avoid history rewriting.

## Improvements

- assign `NoteDetailPush` to the prototype-cell show segue
- structurally require one cell-owned edit segue targeting `DetailViewController`
- independently preserve `NoteDetailAdd` and the save unwind action
- preserve guarded destination/sender casts and selected-note assignment

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- `python3 -m py_compile scripts/check-baseline.py`
- plist, storyboard, XIB, scheme, workspace, SVG, and workflow parsing
- `sh -n build.sh`
- `git diff --check`
- eleven hostile mutations rejected

The local environment did not provide `xcodebuild`; interactive edit navigation and simulator execution were not claimed.

## Risk

The change modifies one existing storyboard attribute and static verification. Add-note routing, save unwind behavior, controller implementation, archive format, file protection, and note persistence semantics remain unchanged.

## Follow-Ups

Hosted macOS CI should compile the exact head through the canonical `make check` workflow. A future UI test can exercise tap-row, edit, save, and relaunch behavior when simulator execution is added to CI.