### PR TITLE
fix: make note checks location independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made all Make verification aliases location-independent when invoked through
+  an absolute Makefile path.
 - Added protected corrupt archive quarantine after readable note data fails
   secure decoding, while leaving unreadable protected archives in place.
 - Restored selected-note identity by assigning `NoteDetailPush` to the

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 lint test build: check
 
 check:
-	python3 scripts/check-baseline.py
+	python3 "$(ROOT)/scripts/check-baseline.py"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   edit routing guardrail.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Swift sources, plist/storyboard/scheme files, persistence behavior, build scripts, or privacy documentation.
+- The same gates may be invoked through an absolute Makefile path from another
+  directory; verification resolves the checker relative to the checkout.
 
 ## Contributing
 

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,12 +1,12 @@
 # Location-Independent Note Taker Verification
 
-status: in progress
+status: completed
 
 ## Context
 
-Absolute Makefile invocations resolve `scripts/check-baseline.py` relative to
-the caller instead of the checkout, so documented verification aliases fail
-outside the repository directory.
+Absolute Makefile invocations previously resolved `scripts/check-baseline.py`
+relative to the caller instead of the checkout, so documented verification
+aliases failed outside the repository directory.
 
 ## Scope
 
@@ -25,6 +25,24 @@ outside the repository directory.
   documentation mutations independently.
 - Inspect intended paths, secret patterns, conflict markers, and generated
   artifacts before commit.
+
+## Work Completed
+
+- Derived the checkout root from the loaded Makefile and invoked the baseline
+  checker by absolute path.
+- Added exact Makefile, completed-plan, external-run, and synchronized guidance
+  contracts without changing persistence, tests, project, or workflow files.
+
+## Verification Completed
+
+- All four Make gates passed from the checkout.
+- All four Make gates passed from `/tmp` through the absolute Makefile path.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`, and
+  project metadata parsing passed; `git diff --check` passed.
+- Local validation reported that `xcodebuild` was unavailable and therefore ran
+  the static iOS baseline only.
+- Five isolated hostile mutations were rejected: root derivation, checker
+  invocation, plan status, plan evidence, and documentation guidance.
 
 ## Risk And Rollback
 

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,32 @@
+# Location-Independent Note Taker Verification
+
+status: in progress
+
+## Context
+
+Absolute Makefile invocations resolve `scripts/check-baseline.py` relative to
+the caller instead of the checkout, so documented verification aliases fail
+outside the repository directory.
+
+## Scope
+
+1. Derive the checkout root from the loaded Makefile.
+2. Invoke the baseline checker from that root for every Make alias.
+3. Add exact Makefile, completed-plan, external-run, and guidance contracts.
+4. Preserve note persistence, tests, project metadata, and workflow policy.
+
+## Verification Plan
+
+- Run all four Make gates from the checkout and through an absolute Makefile
+  path from a temporary directory.
+- Run checker compilation, project metadata parsing, shell syntax, and diff
+  checks.
+- Reject root-derivation, checker-invocation, plan-status, plan-evidence, and
+  documentation mutations independently.
+- Inspect intended paths, secret patterns, conflict markers, and generated
+  artifacts before commit.
+
+## Risk And Rollback
+
+This changes verification path resolution only. Rollback restores the relative
+Make recipe and removes its checker, plan, and documentation contracts.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -25,6 +25,7 @@ SECURE_SWIFT_5_PLAN = ROOT / "docs/plans/2026-06-10-secure-swift-5-persistence.m
 PROTECTED_WRITE_PLAN = ROOT / "docs/plans/2026-06-12-protected-atomic-note-write.md"
 EDIT_SEGUE_PLAN = ROOT / "docs/plans/2026-06-13-edit-note-segue-identifier.md"
 CORRUPT_ARCHIVE_PLAN = ROOT / "docs/plans/2026-06-13-corrupt-note-archive-quarantine.md"
+LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 
 
 def require(condition, message, failures):
@@ -190,6 +191,7 @@ def main():
         "docs/plans/2026-06-12-protected-atomic-note-write.md",
         "docs/plans/2026-06-13-edit-note-segue-identifier.md",
         "docs/plans/2026-06-13-corrupt-note-archive-quarantine.md",
+        "docs/plans/2026-06-13-location-independent-make.md",
         "img/app.gif",
     ]
 
@@ -241,6 +243,7 @@ def main():
     protected_write_plan = PROTECTED_WRITE_PLAN.read_text(encoding="utf-8") if PROTECTED_WRITE_PLAN.exists() else ""
     edit_segue_plan = EDIT_SEGUE_PLAN.read_text(encoding="utf-8") if EDIT_SEGUE_PLAN.exists() else ""
     corrupt_archive_plan = CORRUPT_ARCHIVE_PLAN.read_text(encoding="utf-8") if CORRUPT_ARCHIVE_PLAN.exists() else ""
+    location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(app_plist.get("CFBundlePackageType") == "APPL",
@@ -439,8 +442,12 @@ def main():
     require("*.local.xcconfig" in gitignore and ".env" in gitignore and "DerivedData" in gitignore,
             ".gitignore must exclude local config and Xcode build products",
             failures)
-    require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile,
-            "Makefile must expose lint, test, and build aliases for the local baseline",
+    require(".PHONY: build check lint test" in makefile and
+            "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
+            "lint test build: check" in makefile and
+            'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and
+            "python3 scripts/check-baseline.py" not in makefile,
+            "Makefile must expose location-independent lint, test, build, and check aliases",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "NoteStore.plist" in readme and "local" in readme.lower() and
             "file protection" in readme.lower() and "documents path" in readme.lower() and
@@ -509,11 +516,35 @@ def main():
             "hostile mutations" in edit_segue_plan.lower(),
             "edit note segue plan must record completed status and verification",
             failures)
+    location_make_statuses = re.findall(
+        r"^status: .+$", location_independent_make_plan, flags=re.MULTILINE
+    )
+    location_make_verification = markdown_section(
+        location_independent_make_plan, "Verification Completed"
+    )
+    require(location_make_statuses == ["status: completed"] and
+            "All four Make gates passed from the checkout" in location_make_verification and
+            "All four Make gates passed from `/tmp` through the absolute Makefile path" in location_make_verification and
+            "python3 -m py_compile scripts/check-baseline.py" in location_make_verification and
+            "sh -n build.sh" in location_make_verification and
+            "project metadata parsing" in location_make_verification and
+            "git diff --check" in location_make_verification and
+            "`xcodebuild` was unavailable" in location_make_verification and
+            "Five isolated hostile mutations were rejected" in location_make_verification and
+            re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                      location_make_verification,
+                      re.IGNORECASE) is None,
+            "location-independent Make plan must record completed status and actual local verification",
+            failures)
     require("corrupt archive quarantine" in readme.lower() and
             "corrupt archive quarantine" in security.lower() and
             "quarantine only readable corrupt" in vision.lower() and
             "corrupt archive quarantine" in changes.lower(),
             "Docs must record readable corrupt archive quarantine",
+            failures)
+    require("absolute makefile path" in readme.lower() and
+            "location-independent" in changes.lower(),
+            "README and CHANGES must document location-independent Make verification",
             failures)
     corrupt_archive_statuses = re.findall(
         r"^status: .+$", corrupt_archive_plan, flags=re.MULTILINE


### PR DESCRIPTION
## Summary

The documented Make gates now work when called through an absolute Makefile path from outside the checkout. Verification derives the repository root from the loaded Makefile, while static contracts prevent the path fix or its completed evidence from regressing.

## Baseline

- The documented Make gates previously depended on the caller's working directory.
- Full Xcode build execution is unavailable in the local Linux environment.
- Application behavior, project sources, archive handling, dependencies, and workflows remain outside this verification-focused change.

## Improvements

- Derive the repository root from the loaded Makefile.
- Make the documented quality gates location-independent.
- Add static contracts that protect the path fix and its completed plan evidence from regression.

## Validation

- All four Make gates passed from the checkout and from `/tmp`
- Project plist, XML, and workflow YAML parsing passed
- Checker compilation, `build.sh` syntax, and `git diff --check` passed
- Five isolated hostile mutations were rejected
- Intended-path, secret-pattern, conflict-marker, and generated-artifact audits passed
- Local Linux validation truthfully skipped `xcodebuild`

## Risk

- Full Xcode compilation and runtime behavior were not validated locally because the available environment is Linux.
- This PR is stacked on PR #7 (`lfg/ios-note-taker-corrupt-archive-quarantine-20260613-v2`) and must not be merged independently.

## Follow-Ups

- Preserve and merge PR #7 first, or rebase this work before independent delivery.
- Run the Xcode build and relevant simulator/device checks in a supported macOS environment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
