### PR TITLE
fix: preserve unreadable note archives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@
 - No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
 - Keep signing files, local xcconfig files, and environment files out of git.
 - Notes can contain sensitive personal information. Keep note content local by default, avoid logging note content, and require explicit design before adding sync, upload, analytics, or export behavior.
+- Unreadable existing note archives block persistence writes until a successful secure load or completed corrupt-archive quarantine makes replacement safe.
 - `scripts/check-baseline.py` verifies protected atomic local persistence saves, explicit archive file-protection repair, archive fallback behavior, storyboard cast guards, invalid hex fallback, and static privacy guardrails.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 2026-06-15
+
+- Unreadable existing note archives block persistence writes until a successful secure load or completed corrupt-archive quarantine makes replacement safe.
+
 ## 2026-06-13
 
 - Made all Make verification aliases location-independent when invoked through

--- a/NoteTaker/NoteStore.swift
+++ b/NoteTaker/NoteStore.swift
@@ -8,17 +8,21 @@ class NoteStore {
     static let sharedNoteStore = NoteStore()
 
     private let archiveURL: URL?
+    private let archiveDataLoader: (URL) throws -> Data
+    private var archiveWritesBlocked = false
 
     // Private init to force usage of singleton
     private init() {
         archiveURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
             .first?
             .appendingPathComponent("NoteStore.plist")
+        archiveDataLoader = { try Data(contentsOf: $0) }
         load()
     }
 
-    init(archiveURL: URL?) {
+    init(archiveURL: URL?, archiveDataLoader: @escaping (URL) throws -> Data = { try Data(contentsOf: $0) }) {
         self.archiveURL = archiveURL
+        self.archiveDataLoader = archiveDataLoader
         load()
     }
 
@@ -90,6 +94,9 @@ class NoteStore {
 
     // 2: Do the save to disk.....
     func save() {
+        guard !archiveWritesBlocked else {
+            return
+        }
         guard let url = archiveFileURL() else {
             return
         }
@@ -116,7 +123,7 @@ class NoteStore {
             .appendingPathComponent("NoteStore.corrupt.plist")
     }
 
-    private func quarantineCorruptArchive(_ archiveURL: URL) {
+    private func quarantineCorruptArchive(_ archiveURL: URL) -> Bool {
         let fileManager = FileManager.default
         let quarantineURL = corruptArchiveFileURL(archiveURL)
 
@@ -126,8 +133,10 @@ class NoteStore {
             }
             try fileManager.moveItem(at: archiveURL, to: quarantineURL)
             applyFileProtection(quarantineURL.path)
+            return true
         } catch {
             // Keep note content and local paths out of logs when quarantine fails.
+            return false
         }
     }
 
@@ -139,11 +148,13 @@ class NoteStore {
             return
         }
 
+        let archiveExists = FileManager.default.fileExists(atPath: fileURL.path)
         let data: Data
         do {
-            data = try Data(contentsOf: fileURL)
+            data = try archiveDataLoader(fileURL)
         } catch {
             notes = []
+            archiveWritesBlocked = archiveExists
             return
         }
 
@@ -154,13 +165,14 @@ class NoteStore {
                 from: data
             ) as? [Note] else {
                 notes = []
-                quarantineCorruptArchive(fileURL)
+                archiveWritesBlocked = !quarantineCorruptArchive(fileURL)
                 return
             }
             notes = decodedNotes
+            archiveWritesBlocked = false
         } catch {
             notes = []
-            quarantineCorruptArchive(fileURL)
+            archiveWritesBlocked = !quarantineCorruptArchive(fileURL)
         }
     }
     

--- a/NoteTakerTests/NoteTakerTests.swift
+++ b/NoteTakerTests/NoteTakerTests.swift
@@ -67,6 +67,11 @@ class NoteTakerTests: XCTestCase {
         XCTAssertEqual(store.count(), 0)
         XCTAssertFalse(FileManager.default.fileExists(atPath: urls.archive.path))
         XCTAssertEqual(try Data(contentsOf: urls.quarantine), corruptData)
+
+        let note = store.createNote()
+        note.title = "Recovered"
+        store.updateNote(theNote: note)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: urls.archive.path))
     }
 
     func testWrongArchiveRootTypeIsQuarantined() throws {
@@ -101,6 +106,50 @@ class NoteTakerTests: XCTestCase {
         XCTAssertEqual(store.count(), 1)
         XCTAssertTrue(FileManager.default.fileExists(atPath: urls.archive.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: urls.quarantine.path))
+    }
+
+    func testUnreadableExistingArchiveBlocksReplacementUntilSuccessfulReload() throws {
+        let urls = try temporaryArchiveURLs()
+        defer { try? FileManager.default.removeItem(at: urls.directory) }
+        let originalNote = Note()
+        originalNote.title = "Protected"
+        let originalData = try NSKeyedArchiver.archivedData(
+            withRootObject: [originalNote],
+            requiringSecureCoding: true
+        )
+        try originalData.write(to: urls.archive)
+        var shouldFailRead = true
+        let store = NoteStore(archiveURL: urls.archive) { url in
+            if shouldFailRead {
+                throw CocoaError(.fileReadNoPermission)
+            }
+            return try Data(contentsOf: url)
+        }
+
+        _ = store.createNote()
+        XCTAssertEqual(try Data(contentsOf: urls.archive), originalData)
+
+        shouldFailRead = false
+        store.load()
+        XCTAssertEqual(store.count(), 1)
+        _ = store.createNote()
+
+        let allowedClasses: [AnyClass] = [NSArray.self, Note.self, NSString.self, NSDate.self]
+        let decodedNotes = try NSKeyedUnarchiver.unarchivedObject(
+            ofClasses: allowedClasses,
+            from: Data(contentsOf: urls.archive)
+        ) as? [Note]
+        XCTAssertEqual(decodedNotes?.count, 2)
+    }
+
+    func testMissingArchiveAllowsFirstWrite() throws {
+        let urls = try temporaryArchiveURLs()
+        defer { try? FileManager.default.removeItem(at: urls.directory) }
+        let store = NoteStore(archiveURL: urls.archive)
+
+        _ = store.createNote()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: urls.archive.path))
     }
 
     func testNoteStoreGetNoteRejectsInvalidIndexes() {

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The checked-in project has no external dependency manifest. Use Xcode for full b
 - The mini logo is scoped to each navigation item title view instead of being
   added as a navigation-controller overlay.
 - Notes are local app data stored through `NoteStore.plist` in the app documents area. Saves request complete file protection as part of the atomic replacement and then repair the resulting file attributes explicitly. If the documents path is unavailable, the store keeps an empty in-memory list instead of writing to a fallback path. The app does not sync, upload, or analyze note content.
+- Unreadable existing note archives block persistence writes until a successful secure load or completed corrupt-archive quarantine makes replacement safe.
 
 ## Testing and Verification
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,7 @@ Helpful reports include:
 
 - This repository appears to be an Apple platform application or Swift sample. The active security scope is the code and documentation on the default branch.
 - Note content is sensitive local app data. The current app stores notes locally through `NoteStore.plist`, requests complete file protection during each atomic replacement, repairs the resulting file attributes explicitly, and should not log, sync, upload, analyze, or transmit note content.
+- Unreadable existing note archives block persistence writes until a successful secure load or completed corrupt-archive quarantine makes replacement safe.
 - Persistence, archive decoding, export, sharing, sync, analytics, or network changes should receive security-focused review before merge.
 - Run `make check` before merging changes; it verifies plist/storyboard/scheme metadata, secure coding, protected atomic archive writes, title normalization, decoded title fallback behavior, corrupt archive quarantine, guarded note lookup, delete result handling, reference delete result handling, selected-note identity during edit navigation, navigation logo title view ownership, file-protection repair, archive fallback behavior, source inventory, and note-content privacy guardrails.
 - The pinned macOS workflow uses Python 3.12, read-only repository permissions,

--- a/VISION.md
+++ b/VISION.md
@@ -30,6 +30,7 @@ Priority:
 - Avoid fallback archive writes when the documents path is unavailable
 - Preserve unreadable protected archives and quarantine only readable corrupt
   archive bytes
+- Unreadable existing note archives block persistence writes until a successful secure load or completed corrupt-archive quarantine makes replacement safe.
 - Maintain build script and README context
 - Keep `scripts/check-baseline.py` passing for local-first persistence,
   archive fallback behavior, storyboard guards, and note-content privacy

--- a/docs/plans/2026-06-15-unreadable-archive-write-guard.md
+++ b/docs/plans/2026-06-15-unreadable-archive-write-guard.md
@@ -1,6 +1,6 @@
 # Guard Writes After Unreadable Archive Loads
 
-status: planned
+status: completed
 
 ## Context
 
@@ -70,3 +70,26 @@ turns a temporary protection or I/O failure into permanent note loss.
   patterns.
 - Push a stacked pull request and take one bounded exact-head hosted and
   security-alert snapshot without polling.
+
+## Work Completed
+
+- Added explicit write-block state for existing archives that fail to read.
+- Preserved in-memory CRUD while preventing unsafe archive replacement.
+- Cleared the block after successful secure loads and completed corrupt
+  quarantine, while keeping missing first-run archives writable.
+- Added focused XCTest, static contracts, and synchronized guidance.
+
+## Verification Completed
+
+- All four Make gates passed on the exact candidate implementation; `xcodebuild`
+  was unavailable on Linux, so no local Swift compile or XCTest claim is made.
+- The absolute Makefile passed from `/tmp`.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`, and
+  `git diff --check` passed.
+- Seven hostile mutations were rejected across existing-file detection, early
+  save blocking, successful-load reset, quarantine reset, behavioral coverage,
+  guidance, and plan evidence.
+- Exact intended-path, generated-artifact, project/lockfile/workflow exclusion,
+  conflict-marker, whitespace, and changed-line credential scan passed.
+- The hosted pull-request and security-alert snapshot is recorded separately
+  after push; this plan claims only completed pre-push verification above.

--- a/docs/plans/2026-06-15-unreadable-archive-write-guard.md
+++ b/docs/plans/2026-06-15-unreadable-archive-write-guard.md
@@ -1,0 +1,72 @@
+# Guard Writes After Unreadable Archive Loads
+
+status: planned
+
+## Context
+
+`NoteStore.load()` intentionally preserves an existing archive when
+`Data(contentsOf:)` cannot read it, but it resets in-memory notes to an empty
+array. A later create, update, or delete calls `save()` and may atomically
+replace the preserved archive with that empty or partial in-memory state. This
+turns a temporary protection or I/O failure into permanent note loss.
+
+## Requirements
+
+- R1. Distinguish a missing first-run archive from an existing archive that
+  could not be read.
+- R2. Block persistence writes after an unreadable-existing-archive load so the
+  preserved archive cannot be replaced by empty or partial state.
+- R3. Keep in-memory CRUD behavior available while writes are blocked.
+- R4. Clear the write block after a later successful secure decode.
+- R5. Clear the write block after a readable corrupt archive is quarantined,
+  because the original path is then safe for a new archive.
+- R6. Preserve secure class-restricted decoding, atomic complete-protection
+  writes, corrupt quarantine, guarded edit/delete routing, and local-only note
+  privacy.
+- R7. Add mutation-sensitive source, behavioral, guidance, and completed-plan
+  contracts.
+
+## Implementation Units
+
+### U1. Persistence write state
+
+- **File:** `NoteTaker/NoteStore.swift`
+- Track whether the current archive path is unsafe to replace because an
+  existing file could not be read.
+- Return from `save()` before encoding or writing while that state is active.
+- Reset the state on missing archive, successful decode, and completed corrupt
+  quarantine.
+
+### U2. Regression coverage
+
+- **Files:** `NoteTakerTests/NoteTakerTests.swift`, `scripts/check-baseline.py`
+- Prove a read failure for an existing archive activates the write guard while
+  a missing archive and a quarantined corrupt archive remain writable.
+- Add source-level contracts for guard ordering and transitions.
+
+### U3. Maintenance evidence
+
+- **Files:** `AGENTS.md`, `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Record that unreadable existing archives remain write-protected until a safe
+  load or quarantine transition.
+
+## Scope Boundaries
+
+- Do not add cloud sync, encryption keys, recovery UI, background retries,
+  migrations, new archive formats, or analytics.
+- Do not alter note fields, segue identifiers, table routing, or corrupt-file
+  quarantine naming.
+- Do not edit project metadata, lockfiles, workflows, or generated artifacts.
+
+## Verification Plan
+
+- Run all four Make gates and the absolute Makefile from `/tmp`.
+- Compile the Python checker and validate `build.sh` shell syntax.
+- Reject mutations that remove existing-file detection, the early save guard,
+  successful-load reset, quarantine reset, behavioral coverage, guidance, or
+  completed-plan evidence.
+- Audit exact intended paths, generated artifacts, project/lockfile/workflow
+  exclusions, conflict markers, whitespace, and changed-line credential
+  patterns.
+- Push a stacked pull request and take one bounded exact-head hosted and
+  security-alert snapshot without polling.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -26,6 +26,7 @@ PROTECTED_WRITE_PLAN = ROOT / "docs/plans/2026-06-12-protected-atomic-note-write
 EDIT_SEGUE_PLAN = ROOT / "docs/plans/2026-06-13-edit-note-segue-identifier.md"
 CORRUPT_ARCHIVE_PLAN = ROOT / "docs/plans/2026-06-13-corrupt-note-archive-quarantine.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
+UNREADABLE_ARCHIVE_PLAN = ROOT / "docs/plans/2026-06-15-unreadable-archive-write-guard.md"
 
 
 def require(condition, message, failures):
@@ -192,6 +193,7 @@ def main():
         "docs/plans/2026-06-13-edit-note-segue-identifier.md",
         "docs/plans/2026-06-13-corrupt-note-archive-quarantine.md",
         "docs/plans/2026-06-13-location-independent-make.md",
+        "docs/plans/2026-06-15-unreadable-archive-write-guard.md",
         "img/app.gif",
     ]
 
@@ -244,6 +246,7 @@ def main():
     edit_segue_plan = EDIT_SEGUE_PLAN.read_text(encoding="utf-8") if EDIT_SEGUE_PLAN.exists() else ""
     corrupt_archive_plan = CORRUPT_ARCHIVE_PLAN.read_text(encoding="utf-8") if CORRUPT_ARCHIVE_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
+    unreadable_archive_plan = UNREADABLE_ARCHIVE_PLAN.read_text(encoding="utf-8") if UNREADABLE_ARCHIVE_PLAN.exists() else ""
     workflow = read(".github/workflows/check.yml")
 
     require(app_plist.get("CFBundlePackageType") == "APPL",
@@ -323,6 +326,8 @@ def main():
     require_order(
         store,
         [
+            "guard !archiveWritesBlocked else",
+            "return",
             "guard let url = archiveFileURL() else",
             "return",
             "NSKeyedArchiver.archivedData(withRootObject: notes, requiringSecureCoding: true)",
@@ -344,25 +349,27 @@ def main():
             "return nil" in get_note.group(0),
             "getNote(index:) must reject invalid note indexes instead of indexing directly",
             failures)
-    require("let data: Data" in store and
-            "data = try Data(contentsOf: fileURL)" in store and
-            "} catch {\n            notes = []\n            return\n        }\n\n        do {" in store,
-            "load must leave unreadable protected archives in place before decode handling",
+    require("private var archiveWritesBlocked = false" in store and
+            "let archiveExists = FileManager.default.fileExists(atPath: fileURL.path)" in store and
+            "data = try archiveDataLoader(fileURL)" in store and
+            "archiveWritesBlocked = archiveExists" in store,
+            "load must block writes only when an existing archive cannot be read",
             failures)
     require("let allowedClasses: [AnyClass] = [NSArray.self, Note.self, NSString.self, NSDate.self]" in store and
             "guard let decodedNotes = try NSKeyedUnarchiver.unarchivedObject(" in store and
             ") as? [Note] else {" in store and
-            store.count("quarantineCorruptArchive(fileURL)") == 2 and
-            "notes = decodedNotes" in store,
+            store.count("archiveWritesBlocked = !quarantineCorruptArchive(fileURL)") == 2 and
+            "notes = decodedNotes\n            archiveWritesBlocked = false" in store,
             "load must quarantine thrown and wrong-root secure decode failures",
             failures)
-    require("func quarantineCorruptArchive(_ archiveURL: URL)" in store and
+    require("func quarantineCorruptArchive(_ archiveURL: URL) -> Bool" in store and
             "NoteStore.corrupt.plist" in store and
             "fileManager.fileExists(atPath: quarantineURL.path)" in store and
             "try fileManager.removeItem(at: quarantineURL)" in store and
             "try fileManager.moveItem(at: archiveURL, to: quarantineURL)" in store and
-            "applyFileProtection(quarantineURL.path)" in store,
-            "corrupt archive quarantine must replace stale quarantine and preserve file protection",
+            "applyFileProtection(quarantineURL.path)\n            return true" in store and
+            "return false" in store,
+            "corrupt archive quarantine must report whether the live path is safe to replace",
             failures)
     require_order(
         store,
@@ -370,7 +377,7 @@ def main():
             "guard let fileURL = archiveFileURL() else",
             "notes = []",
             "return",
-            "Data(contentsOf: fileURL)",
+            "archiveDataLoader(fileURL)",
         ],
         "load must fall back to an empty note list when the Documents path is unavailable",
         failures,
@@ -390,6 +397,9 @@ def main():
             "testReadableCorruptArchiveIsQuarantined" in unit_tests and
             "testWrongArchiveRootTypeIsQuarantined" in unit_tests and
             "testValidArchiveRemainsAtLivePath" in unit_tests and
+            "testUnreadableExistingArchiveBlocksReplacementUntilSuccessfulReload" in unit_tests and
+            "testMissingArchiveAllowsFirstWrite" in unit_tests and
+            "XCTAssertEqual(try Data(contentsOf: urls.archive), originalData)" in unit_tests and
             "XCTAssert(true" not in unit_tests and "testPerformanceExample" not in unit_tests,
             "NoteTakerTests must replace template tests with note-title normalization assertions",
             failures)
@@ -542,6 +552,11 @@ def main():
             "corrupt archive quarantine" in changes.lower(),
             "Docs must record readable corrupt archive quarantine",
             failures)
+    unreadable_archive_guidance = "Unreadable existing note archives block persistence writes until a successful secure load or completed corrupt-archive quarantine makes replacement safe."
+    require(all(unreadable_archive_guidance in document for document in
+                [readme, security, vision, changes, read("AGENTS.md")]),
+            "Docs must record unreadable archive write blocking",
+            failures)
     require("absolute makefile path" in readme.lower() and
             "location-independent" in changes.lower(),
             "README and CHANGES must document location-independent Make verification",
@@ -572,6 +587,28 @@ def main():
                           corrupt_archive_verification,
                           re.IGNORECASE) is None,
             "corrupt note archive quarantine plan must record completed status and actual local verification",
+            failures)
+    unreadable_archive_statuses = re.findall(
+        r"^status: .+$", unreadable_archive_plan, flags=re.MULTILINE
+    )
+    unreadable_archive_verification = markdown_section(
+        unreadable_archive_plan, "Verification Completed"
+    )
+    unreadable_archive_required = (
+        "All four Make gates passed",
+        "absolute Makefile passed from `/tmp`",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "hostile mutations were rejected",
+        "changed-line credential scan passed",
+        "hosted pull-request and security-alert snapshot",
+    )
+    require(unreadable_archive_statuses == ["status: completed"] and
+            all(item in unreadable_archive_verification
+                for item in unreadable_archive_required) and
+            re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                      unreadable_archive_verification,
+                      re.IGNORECASE) is None,
+            "unreadable archive write-guard plan must record completed verification",
             failures)
     protected_write_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", protected_write_plan


### PR DESCRIPTION
## Summary

An existing protected note archive can be temporarily unreadable, and the store correctly left that file in place but reset memory to an empty list. Any later create, update, or delete then attempted a save and could replace the preserved archive with empty or partial state.

The store now blocks persistence writes after an unreadable-existing-file load. Missing first-run archives remain writable, successful secure reloads clear the block, and completed corrupt-archive quarantine clears it because the live path is safe again. In-memory CRUD remains available while blocked, without changing the archive schema, note fields, UI routing, or local-only privacy boundary.

## Baseline

The prior load path preserved an unreadable archive on disk but left persistence enabled. A later in-memory create, update, or delete could therefore save empty or partial state over the protected archive.

## Improvements

- Block persistence after an existing archive fails to load while keeping in-memory CRUD available.
- Keep missing first-run archives writable.
- Clear the block after a successful secure reload or completed corrupt-archive quarantine.
- Preserve the archive schema, note fields, UI routing, and local-only privacy boundary.

## Validation

- `make check`, `make lint`, `make test`, and `make build`
- Absolute `Makefile` invocation from `/tmp`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n build.sh`
- Seven mutation-sensitive regression cases
- Exact diff, generated-artifact, project/lockfile/workflow exclusion, conflict-marker, whitespace, and changed-line credential audits

`xcodebuild` is unavailable in the Linux environment, so Swift compilation and XCTest remain hosted macOS validation responsibilities.

## Risk

The change affects archive write eligibility after load failures. Local policy and regression checks passed, and both exact-head hosted macOS checks completed successfully. Full iOS file-protection behavior still requires compatible device or simulator validation.

## Follow-Ups

- Keep the unreadable archive preserved and persistence blocked until a successful secure reload or completed quarantine makes the live path safe.
- Exercise protected-file failure, recovery, and quarantine behavior on a compatible Apple host without logging note content.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)